### PR TITLE
Include error as description for parse errors closes

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -427,7 +427,7 @@ export class Manager<
     try {
       this.decoder.add(data);
     } catch (e) {
-      this.onclose("parse error");
+      this.onclose("parse error", e as Error);
     }
   }
 


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

When the client has an error decoding incoming data, it will currently close current connection, which will retrigger a reconnect. However, there's no good way to know what might have caused the `parse error` and makes debugging them much harder.

### New behaviour

Now, the error that was raised during parsing is attached as the optional `description` field on the `onclose` and so the user can get at it as described in the [4.5.0 release notes](https://github.com/socketio/socket.io-client/blob/main/CHANGELOG.md#450-2022-04-23).

The error includes the data for ease of debugging, but that could probably be removed as that info should be accessible via the network inspection.

### Other information (e.g. related issues)

Closes #1554